### PR TITLE
v0.21.0

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -35,7 +35,8 @@ jobs:
       - name: Test wheel
         run: |
           uv venv
-          uv pip install "dist/duckboat-*-py3-none-any.whl[testing]"
+          cp dist/duckboat-*-py3-none-any.whl dist/duckboat.whl
+          uv pip install "dist/duckboat.whl[testing]"
           .venv/bin/pytest
 
   to_pypi:

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Test wheel
         run: |
           uv venv
-          uv pip install dist/duckboat-*-py3-none-any.whl pytest pytest-cov
+          uv pip install "dist/duckboat-*-py3-none-any.whl[testing]"
           .venv/bin/pytest
 
   to_pypi:

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -35,8 +35,7 @@ jobs:
       - name: Test wheel
         run: |
           uv venv
-          cp dist/duckboat-*-py3-none-any.whl dist/duckboat.whl
-          uv pip install "dist/duckboat.whl[testing]"
+          uv pip install "$(ls dist/duckboat-*-py3-none-any.whl)[testing]"
           .venv/bin/pytest
 
   to_pypi:

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+# v0.21.0 (2026-03-26)
+
+- `Table` implements `__arrow_c_stream__`, making it consumable by any Arrow-aware library
+- input accepts any object implementing `__arrow_c_stream__` (pandas, Polars, PyArrow, cuDF, etc.)
+- explicit type validation with clear error messages for unsupported inputs
+- improved error messages when file/URL reads fail
+- polars added to test matrix
+
 # v0.20.0 (2026-03-26)
 
 - t-string support (Python 3.14+): `t'select * from {orders} join {customers} using (id)'`

--- a/docs/concepts.qmd
+++ b/docs/concepts.qmd
@@ -21,6 +21,32 @@ t.do('pandas')  # Pandas DataFrame
 t.do('arrow')   # PyArrow Table
 ```
 
+## Arrow PyCapsule compatibility
+
+`Table` accepts any object implementing `__arrow_c_stream__` as input---pandas,
+Polars, PyArrow, cuDF, or any other Arrow-compatible library:
+
+```python
+import polars as pl
+
+df = pl.DataFrame({'a': [1, 2, 3]})
+t = uck.do(df, 'select sum(a)', int)  # 6
+```
+
+`Table` also implements `__arrow_c_stream__` itself, so other libraries can
+consume it directly:
+
+```python
+import pyarrow as pa
+
+t = uck.do('data/penguins.parquet')
+pa.RecordBatchReader.from_stream(t)  # zero-copy
+pl.from_arrow(t)                     # zero-copy
+```
+
+This means duckboat interoperates with the Arrow ecosystem in both
+directions without explicit conversion.
+
 ## Table
 
 `Table` is the core object---it wraps a DuckDB `DuckDBPyRelation`. You get one

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'duckboat'
-version = '0.20.0'
+version = '0.21.0'
 description = 'A SQL-based Python dataframe library for ergonomic interactive data analysis and exploration.'
 authors = [
     { name = 'AJ Friend', email = 'ajfriend@gmail.com' }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ requires = ['tox-uv']
 
 [tool.tox.env_run_base]
 runner = 'uv-venv-runner'
-deps = ['pytest', 'coverage']
+deps = ['pytest', 'coverage', 'polars']
 commands = [['coverage', 'run', '-m', 'pytest']]
 
 [tool.tox.env.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,15 @@ dependencies = [
     'pandas',
 ]
 
+[project.optional-dependencies]
+testing = ['pytest', 'pytest-cov', 'coverage', 'polars']
+
 [dependency-groups]
 dev = [
-    'pytest', 'coverage', 'ruff',
+    'pytest', 'pytest-cov', 'coverage', 'polars',
+    'ruff',
     'jupyterlab', 'ipykernel', 'jupyterlab_execute_time',
     'matplotlib',
-    'polars',
 ]
 
 [project.urls]
@@ -118,7 +121,7 @@ requires = ['tox-uv']
 
 [tool.tox.env_run_base]
 runner = 'uv-venv-runner'
-deps = ['pytest', 'coverage', 'polars']
+extras = ['testing']
 commands = [['coverage', 'run', '-m', 'pytest']]
 
 [tool.tox.env.report]

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ uck.do(
 
 ### To and from other data formats
 
-We can translate to and from other data formats like Pandas DataFrames, Polars, or Arrow Tables.
+`Table` implements the [Arrow PyCapsule Interface](https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html) (`__arrow_c_stream__`), so it interoperates with any Arrow-compatible library---pandas, Polars, PyArrow, cuDF.
 
 ```python
 import pandas as pd

--- a/src/duckboat/_tstrings.py
+++ b/src/duckboat/_tstrings.py
@@ -22,10 +22,15 @@ def _process_template(template):
             elif isinstance(value, str):
                 escaped = value.replace("'", "''")
                 parts.append(f"'{escaped}'")
-            else:
+            elif hasattr(value, '__arrow_c_stream__'):
                 expr = item.expression
                 name = expr if expr.isidentifier() else _random_name()
                 tables[name] = value
                 parts.append(name)
+            else:
+                raise TypeError(
+                    f'Expected a scalar or tabular object in t-string, '
+                    f'got {type(value).__name__}'
+                )
 
     return ''.join(parts), tables

--- a/src/duckboat/ddb/_relation.py
+++ b/src/duckboat/ddb/_relation.py
@@ -1,15 +1,18 @@
+from pathlib import Path
+
 from ._query import __duckboat_query__ as query
 from duckdb import DuckDBPyRelation
 
 
 def form_relation(x) -> DuckDBPyRelation:
-    """
-    inputs: string of filename, actual file, string of remote file, dataframe,
-    dictionary, polars, pyarrow, filename of database
-    """
-    # if isinstance(df, Relation):
-    #     df = df.arrow()
-    if isinstance(x, str):
-        return query(f'select * from "{x}"')
-    else:
+    if hasattr(x, '__arrow_c_stream__'):
         return query('select * from x', x=x)
+    if isinstance(x, (str, Path)):
+        try:
+            return query(f'select * from "{x}"')
+        except Exception as e:
+            raise type(e)(f'Could not read {x!r}: {e}') from e
+    raise TypeError(
+        f'Expected a tabular object implementing __arrow_c_stream__ '
+        f'or a filename string — got {type(x).__name__}'
+    )

--- a/src/duckboat/table.py
+++ b/src/duckboat/table.py
@@ -32,6 +32,9 @@ class Table(TableMixin, DoMixin):
     def show(self):
         return Table(self, _hide=False)
 
+    def __arrow_c_stream__(self, requested_schema=None):
+        return self.rel.__arrow_c_stream__(requested_schema)
+
     def rowcols(self):
         if self._hide:
             return _HIDDEN_REPR

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -110,6 +110,30 @@ def test_rename_after_chain():
     assert out == 9
 
 
+def test_arrow_dict_value():
+    import pyarrow as pa
+
+    t = pa.table({'x': [1, 2, 3]})
+    out = uck.do(
+        {'t': t},
+        'select sum(x) from t',
+        int,
+    )
+    assert out == 6
+
+
+def test_polars_dict_value():
+    import polars as pl
+
+    df = pl.DataFrame({'x': [1, 2, 3]})
+    out = uck.do(
+        {'t': df},
+        'select sum(x) from t',
+        int,
+    )
+    assert out == 6
+
+
 def test_rename_no_table():
     with pytest.raises(ValueError, match='no implicit table'):
         uck.do({'a': pd.DataFrame({'x': [1]})}, uck.rename('b'))

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -24,7 +24,7 @@ def test_bad_object():
 
     df = pd.DataFrame({'a': [0]})
 
-    with pytest.raises(duckdb.InvalidInputException):
+    with pytest.raises(TypeError, match='__arrow_c_stream__'):
         uck.Table(df).do(foo, 'select *')
 
 
@@ -75,6 +75,29 @@ def test_to_from_parquet():
         t1.save(name)
         t2 = uck.Table(name)
         assert repr(t1) == repr(t2)
+
+
+def test_arrow_c_stream_roundtrip():
+    import pyarrow as pa
+
+    df = pd.DataFrame({'a': [1, 2, 3], 'b': ['x', 'y', 'z']})
+    t = uck.Table(df)
+
+    reader = pa.RecordBatchReader.from_stream(t)
+    table = reader.read_all()
+    assert table.column_names == ['a', 'b']
+    assert table['a'].to_pylist() == [1, 2, 3]
+    assert table['b'].to_pylist() == ['x', 'y', 'z']
+
+
+def test_bad_type_error():
+    with pytest.raises(TypeError, match='__arrow_c_stream__'):
+        uck.Table(42)
+
+
+def test_missing_file_error():
+    with pytest.raises(duckdb.IOException, match='nonexistent.parquet'):
+        uck.Table('nonexistent.parquet')
 
 
 def test_to_unknown_format():

--- a/tests/test_tstrings.py
+++ b/tests/test_tstrings.py
@@ -1,5 +1,6 @@
 import duckboat as uck
 import pandas as pd
+import pytest
 
 
 def test_tstring_join():
@@ -106,3 +107,9 @@ def test_tstring_mixed():
         list,
     )
     assert out == ['b', 'c']
+
+
+def test_tstring_bad_type():
+    bad = object()
+    with pytest.raises(TypeError, match='tabular object'):
+        uck.do(t'select * from {bad}')


### PR DESCRIPTION
# v0.21.0 (2026-03-26)

- `Table` implements `__arrow_c_stream__`, making it consumable by any Arrow-aware library
- input accepts any object implementing `__arrow_c_stream__` (pandas, Polars, PyArrow, cuDF, etc.)
- explicit type validation with clear error messages for unsupported inputs
- improved error messages when file/URL reads fail
- polars added to test matrix